### PR TITLE
修正「𥘀」（U+25600）「𦣙」（U+268D9）右旁取碼

### DIFF
--- a/Cangjie5.txt
+++ b/Cangjie5.txt
@@ -2266,7 +2266,6 @@
 𣎊	bahu
 䐚	bail
 𬛑	baiu
-𦣙	bajv
 𠖇	bak
 𦜃	bak
 幂	bakb
@@ -2308,6 +2307,7 @@
 𫆳	bawe
 冥	bayc
 𧔲	bayi
+𦣙	bayv
 朋	bb
 肎	bb
 冎	bb
@@ -53392,7 +53392,6 @@
 䃏	mrahm
 𭄓	mrahn
 𰦸	mraj
-𥘀	mrajv
 𥑲	mram
 碭	mramh
 碍	mrami
@@ -53418,6 +53417,7 @@
 硍	mrav
 礘	mravf
 𥖉	mrayf
+𥘀	mrayv
 䑚	mrb
 硼	mrbb
 磆	mrbbb

--- a/Cangjie5_SC.txt
+++ b/Cangjie5_SC.txt
@@ -2266,7 +2266,6 @@
 𣎊	bahu
 䐚	bail
 𬛑	baiu
-𦣙	bajv
 𠖇	bak
 𦜃	bak
 幂	bakb
@@ -2308,6 +2307,7 @@
 𫆳	bawe
 冥	bayc
 𧔲	bayi
+𦣙	bayv
 朋	bb
 肎	bb
 冎	bb
@@ -53392,7 +53392,6 @@
 䃏	mrahm
 𭄓	mrahn
 𰦸	mraj
-𥘀	mrajv
 𥑲	mram
 碭	mramh
 碍	mrami
@@ -53418,6 +53417,7 @@
 硍	mrav
 礘	mravf
 𥖉	mrayf
+𥘀	mrayv
 䑚	mrb
 硼	mrbb
 磆	mrbbb

--- a/Cangjie5_TC.txt
+++ b/Cangjie5_TC.txt
@@ -2266,7 +2266,6 @@
 𣎊	bahu
 䐚	bail
 𬛑	baiu
-𦣙	bajv
 𠖇	bak
 𦜃	bak
 幂	bakb
@@ -2308,6 +2307,7 @@
 𫆳	bawe
 冥	bayc
 𧔲	bayi
+𦣙	bayv
 朋	bb
 肎	bb
 冎	bb
@@ -53392,7 +53392,6 @@
 䃏	mrahm
 𭄓	mrahn
 𰦸	mraj
-𥘀	mrajv
 𥑲	mram
 碭	mramh
 碍	mrami
@@ -53418,6 +53417,7 @@
 硍	mrav
 礘	mravf
 𥖉	mrayf
+𥘀	mrayv
 䑚	mrb
 硼	mrbb
 磆	mrbbb

--- a/change_details.log
+++ b/change_details.log
@@ -7896,3 +7896,6 @@ FA1E	羽	smsmm	smsim
 2E891	𮢑	qhss	chss	另有𮢑：ciss
 2EAD2	𮫒	dhfbw	shfbw
 3002B	𰀫	hn	ln
+==2021.08.13==
+25600	𥘀	mrajv	mrayv
+268D9	𦣙	bajv	bayv


### PR DESCRIPTION
兩字原取碼 MRAJV、BAJV，右旁取 AJV 有誤。

兩字右旁均為「曩」（AYRV），並無 Unicode 同碼位異體。

故當取 MRAYV、BAYV 為是。