### PR TITLE
修正「𡮢」（U+21BA2）FBRA -> FBRYA

### DIFF
--- a/Cangjie5.txt
+++ b/Cangjie5.txt
@@ -17608,7 +17608,6 @@
 炯	fbr
 尙	fbr
 𫩠	fbr
-𡮢	fbra
 𬻬	fbram
 𨜂	fbrau
 賞	fbrbc
@@ -17646,6 +17645,7 @@
 黨	fbrwf
 𧒾	fbrwi
 𭟚	fbrwp
+𡮢	fbrya
 𣥺	fbrym
 𫵁	fbrym
 𫵂	fbrym

--- a/Cangjie5_SC.txt
+++ b/Cangjie5_SC.txt
@@ -17608,7 +17608,6 @@
 炯	fbr
 尙	fbr
 𫩠	fbr
-𡮢	fbra
 𬻬	fbram
 𨜂	fbrau
 賞	fbrbc
@@ -17646,6 +17645,7 @@
 黨	fbrwf
 𧒾	fbrwi
 𭟚	fbrwp
+𡮢	fbrya
 𣥺	fbrym
 𫵁	fbrym
 𫵂	fbrym

--- a/Cangjie5_TC.txt
+++ b/Cangjie5_TC.txt
@@ -17608,7 +17608,6 @@
 炯	fbr
 尙	fbr
 𫩠	fbr
-𡮢	fbra
 𬻬	fbram
 𨜂	fbrau
 賞	fbrbc
@@ -17646,6 +17645,7 @@
 黨	fbrwf
 𧒾	fbrwi
 𭟚	fbrwp
+𡮢	fbrya
 𣥺	fbrym
 𫵁	fbrym
 𫵂	fbrym

--- a/change_details.log
+++ b/change_details.log
@@ -7896,3 +7896,5 @@ FA1E	羽	smsmm	smsim
 2E891	𮢑	qhss	chss	另有𮢑：ciss
 2EAD2	𮫒	dhfbw	shfbw
 3002B	𰀫	hn	ln
+==2021.08.26==
+21BA2	𡮢	fbra	fbrya


### PR DESCRIPTION
此字原取碼 FBRA 僅取四碼而略去中間「亠」，原理不明。

此字無論如何拆分均能五碼取全（除非整個視作連體字，但顯然不可能）。
取碼當為 FBRYA。