### PR TITLE
U+25600「𥘀」U+268D9「𦣙」再修正

### DIFF
--- a/Cangjie5.txt
+++ b/Cangjie5.txt
@@ -53392,7 +53392,7 @@
 䃏	mrahm
 𭄓	mrahn
 𰦸	mraj
-𥘀	mrajv
+𥘀	mrajv	[U]
 𥑲	mram
 碭	mramh
 碍	mrami

--- a/Cangjie5.txt
+++ b/Cangjie5.txt
@@ -2266,6 +2266,7 @@
 𣎊	bahu
 䐚	bail
 𬛑	baiu
+𦣙	bajv
 𠖇	bak
 𦜃	bak
 幂	bakb
@@ -2307,7 +2308,6 @@
 𫆳	bawe
 冥	bayc
 𧔲	bayi
-𦣙	bayv
 朋	bb
 肎	bb
 冎	bb
@@ -53392,6 +53392,7 @@
 䃏	mrahm
 𭄓	mrahn
 𰦸	mraj
+𥘀	mrajv
 𥑲	mram
 碭	mramh
 碍	mrami

--- a/Cangjie5_SC.txt
+++ b/Cangjie5_SC.txt
@@ -53392,7 +53392,7 @@
 䃏	mrahm
 𭄓	mrahn
 𰦸	mraj
-𥘀	mrajv
+𥘀	mrajv	[U]
 𥑲	mram
 碭	mramh
 碍	mrami

--- a/Cangjie5_SC.txt
+++ b/Cangjie5_SC.txt
@@ -2266,6 +2266,7 @@
 𣎊	bahu
 䐚	bail
 𬛑	baiu
+𦣙	bajv
 𠖇	bak
 𦜃	bak
 幂	bakb
@@ -2307,7 +2308,6 @@
 𫆳	bawe
 冥	bayc
 𧔲	bayi
-𦣙	bayv
 朋	bb
 肎	bb
 冎	bb
@@ -53392,6 +53392,7 @@
 䃏	mrahm
 𭄓	mrahn
 𰦸	mraj
+𥘀	mrajv
 𥑲	mram
 碭	mramh
 碍	mrami

--- a/Cangjie5_TC.txt
+++ b/Cangjie5_TC.txt
@@ -53392,7 +53392,7 @@
 䃏	mrahm
 𭄓	mrahn
 𰦸	mraj
-𥘀	mrajv
+𥘀	mrajv	[U]
 𥑲	mram
 碭	mramh
 碍	mrami

--- a/Cangjie5_TC.txt
+++ b/Cangjie5_TC.txt
@@ -2266,6 +2266,7 @@
 𣎊	bahu
 䐚	bail
 𬛑	baiu
+𦣙	bajv
 𠖇	bak
 𦜃	bak
 幂	bakb
@@ -2307,7 +2308,6 @@
 𫆳	bawe
 冥	bayc
 𧔲	bayi
-𦣙	bayv
 朋	bb
 肎	bb
 冎	bb
@@ -53392,6 +53392,7 @@
 䃏	mrahm
 𭄓	mrahn
 𰦸	mraj
+𥘀	mrajv
 𥑲	mram
 碭	mramh
 碍	mrami

--- a/change_details.log
+++ b/change_details.log
@@ -7896,10 +7896,9 @@ FA1E	羽	smsmm	smsim
 2E891	𮢑	qhss	chss	另有𮢑：ciss
 2EAD2	𮫒	dhfbw	shfbw
 3002B	𰀫	hn	ln
-==2021.08.13==
-25600	𥘀	mrajv	mrayv
-268D9	𦣙	bajv	bayv
 ==2021.08.26==
 21BA2	𡮢	fbra	fbrya
 ==2021.09.05==
 53FD	叽	rlu	(刪除)	叽：rhn
+==2021.09.08==
+25600	𥘀	(新增)	mrayv	另有𥘀：mrajv


### PR DESCRIPTION
Partially reverts #215

據[此評論](https://github.com/Jackchows/Cangjie5/pull/215#issuecomment-914624799)，Unicode 原表（第 13 版）列出了 U+25600「𥘀」兩種形（分別對應 MRAJV 與 MRAYV），而 U+268D9「𦣙」僅一形（對應 BAJV）。

故 U+268D9「𦣙」恢復原 BAJV 碼，U+25600「𥘀」則兩形皆取。
